### PR TITLE
fix: remove gu.com references

### DIFF
--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -294,8 +294,7 @@ as they settle across Europe</a>
                 <p class="gvr-vr__description">
                     There are approximately 31,500 asylum seekers in the UK waiting for a decision about their asylum status. This film allows you to experience what it is like to live in this period of limbo, waiting for a decision that will affect the rest of your life.
                 </p>
-                <!--<button class="gvr-vr__previewbtn" data-url="https://gu.com/p/6m8a2">View trailer</button>-->
-                <button class="gvr-vr__previewbtn" data-url="https://gu.com/p/6k7em">Watch online</button>
+                <button class="gvr-vr__previewbtn" data-url="https://www.theguardian.com/technology/2017/jul/05/limbo-a-virtual-experience-of-waiting-for-asylum-360-video">Watch online</button>
                 <div class="gvr-vr__extras">
                     <div class="gvr-vr__extras__left">
                         <h2>Further material</h2>
@@ -326,17 +325,16 @@ as they settle across Europe</a>
                 <p class="gvr-vr__description">
                     Using the latest research in neural development and colour vision in infants, this film allows you to experience and interact with the world from the point of view of a baby. It's a period that none of us remember, but is the most crucial stage of our development.
                 </p>
-                <!--<button class="gvr-vr__previewbtn" data-url="https://gu.com/p/68ybj">View trailer</button>-->
                 <button class="gvr-vr__trailerbtn" data-video="https://www.youtube.com/embed/N9C9w8sDVLk?autoplay=1&controls=1&modestbranding=1&enablejsapi=1&color=white&showinfo=0&theme=dark&autohide=1&rel=0&iv_load_policy=3&widgetid=1">360 video</button>
                 <div class="gvr-vr__extras">
                     <div class="gvr-vr__extras__left">
                         <h2>Further material</h2>
                         <ul class="gvr-reading">
                             <li class="gvr-reading__item">
-                                <a href="https://gu.com/p/67kqq">First Impressions: what can babies see? - Science Weekly Podcast</a>
+                                <a href="https://www.theguardian.com/science/audio/2017/apr/11/first-impressions-what-can-babies-see-science-weekly-podcast">First Impressions: what can babies see? - Science Weekly Podcast</a>
                             </li>
                             <li class="gvr-reading__item">
-                                <a href="https://gu.com/p/68cjb">The vision thing: how babies colour in the world</a>
+                                <a href="https://www.theguardian.com/lifeandstyle/2017/apr/11/vision-thing-how-babies-colour-in-the-world">The vision thing: how babies colour in the world</a>
                             </li>
                         </ul>
                     </div>
@@ -449,7 +447,7 @@ as they settle across Europe</a>
                 <p class="gvr-vr__description">
                     Pit your wits against a wily street hustler (played by Dan Skinner) in the heart of the City of London. But be on your guard – they say you always win your first game, always lose your second. You'll need all your powers of observation and concentration to come out on top.
                 </p>
-                <button class="gvr-vr__previewbtn" data-url="https://gu.com/p/6qx2b2">View trailer</button>
+                <button class="gvr-vr__previewbtn" data-url="https://www.theguardian.com/technology/video/2017/jul/24/beat-the-hustler-a-virtual-experience-of-a-street-con-trailer-video">View trailer</button>
             </div>
         </div>
     </div>
@@ -466,7 +464,7 @@ as they settle across Europe</a>
                     Take a journey through the subterranean labyrinth of London's Victorian sewers with urban explorer and geographer Bradley Garrett. The experience begins below the streets in one of London's lost waterways, the river Fleet, and continues through the blood sewers underneath Smithfield meat market and down to the floodgates of the river Thames.
                 </p>
                 <button class="gvr-vr__trailerbtn" data-video="https://www.youtube.com/embed/rgQJH9_xgpo?autoplay=1&controls=1&modestbranding=1&enablejsapi=1&color=white&showinfo=0&theme=dark&autohide=1&rel=0&iv_load_policy=3&widgetid=1">View trailer</button>
-                <button class="gvr-vr__previewbtn" data-url="https://gu.com/p/5amda">Interactive version</button>
+                <button class="gvr-vr__previewbtn" data-url="https://www.theguardian.com/cities/ng-interactive/2016/nov/10/subterranean-london">Interactive version</button>
                 <div class="gvr-vr__extras">
                     <div class="gvr-vr__extras__left">
                         <h2>Further material</h2>


### PR DESCRIPTION
## What does this change?

`gu.com ` no longer works. I've updated the URLs to use the whole URL, even though `https://www.theguardian.com/p/{id}` works as I'm not sure why we would want to redirect readers rather than just send them to the URL directly.

